### PR TITLE
add license

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,3 +21,10 @@ any newly created files should be deleted.  To revert files in the git
 repository use:
 
 	git checkout -- test_files/
+
+License
+-------
+
+This work is licensed under the Creative Commons Attribution 4.0 International
+License. To view a copy of this license, visit http://creativecommons.org/licenses/by/4.0/
+or send a letter to Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.


### PR DESCRIPTION
I want to package this files as part of the debian package of the emacs editorconfig plugin and I need some license to attach to this files.

I propose this CC one as the most liberal. It is also DFSG free:
https://wiki.debian.org/DFSGLicenses#Creative_Commons_Attribution_unported_.28CC-BY.29_v4.0

Thanks in advance!